### PR TITLE
[chore] Global 공통 설정 구현 (#2)

### DIFF
--- a/backend/src/main/java/com/lumi/backend/BackendApplication.java
+++ b/backend/src/main/java/com/lumi/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.lumi.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/com/lumi/backend/analyze/controller/AnalyzeController.java
+++ b/backend/src/main/java/com/lumi/backend/analyze/controller/AnalyzeController.java
@@ -1,0 +1,26 @@
+package com.lumi.backend.analyze.controller;
+
+import com.lumi.backend.analyze.dto.AnalyzeRequest;
+import com.lumi.backend.analyze.dto.AnalyzeResponse;
+import com.lumi.backend.analyze.service.AnalyzeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class AnalyzeController {
+
+    private final AnalyzeService analyzeService;
+
+    public AnalyzeController(AnalyzeService analyzeService) {
+        this.analyzeService = analyzeService;
+    }
+
+    @PostMapping("/analyze")
+    public ResponseEntity<AnalyzeResponse> analyze(@RequestBody AnalyzeRequest request) {
+        return ResponseEntity.ok(analyzeService.analyze(request));
+    }
+}

--- a/backend/src/main/java/com/lumi/backend/analyze/dto/AnalyzeRequest.java
+++ b/backend/src/main/java/com/lumi/backend/analyze/dto/AnalyzeRequest.java
@@ -1,0 +1,4 @@
+package com.lumi.backend.analyze.dto;
+
+public record AnalyzeRequest(String log) {
+}

--- a/backend/src/main/java/com/lumi/backend/analyze/dto/AnalyzeResponse.java
+++ b/backend/src/main/java/com/lumi/backend/analyze/dto/AnalyzeResponse.java
@@ -1,0 +1,10 @@
+package com.lumi.backend.analyze.dto;
+
+import java.util.List;
+
+public record AnalyzeResponse(
+        String summary,
+        List<String> errors,
+        String suggestion
+) {
+}

--- a/backend/src/main/java/com/lumi/backend/analyze/service/AnalyzeService.java
+++ b/backend/src/main/java/com/lumi/backend/analyze/service/AnalyzeService.java
@@ -1,0 +1,8 @@
+package com.lumi.backend.analyze.service;
+
+import com.lumi.backend.analyze.dto.AnalyzeRequest;
+import com.lumi.backend.analyze.dto.AnalyzeResponse;
+
+public interface AnalyzeService {
+    AnalyzeResponse analyze(AnalyzeRequest request);
+}

--- a/backend/src/main/java/com/lumi/backend/global/apiPayload/ApiResponse.java
+++ b/backend/src/main/java/com/lumi/backend/global/apiPayload/ApiResponse.java
@@ -1,0 +1,38 @@
+package com.lumi.backend.global.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.lumi.backend.global.apiPayload.code.BaseErrorCode;
+import com.lumi.backend.global.apiPayload.code.BaseSuccessCode;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+    private final T result;
+
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode successCode, T result) {
+        return ApiResponse.<T>builder()
+                .isSuccess(true)
+                .code(successCode.getCode())
+                .message(successCode.getMessage())
+                .result(result)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode errorCode, T result) {
+        return ApiResponse.<T>builder()
+                .isSuccess(false)
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .result(result)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/lumi/backend/global/apiPayload/code/BaseErrorCode.java
+++ b/backend/src/main/java/com/lumi/backend/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package com.lumi.backend.global.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    String getCode();
+
+    String getMessage();
+
+    int getHttpStatus();
+}

--- a/backend/src/main/java/com/lumi/backend/global/apiPayload/code/BaseSuccessCode.java
+++ b/backend/src/main/java/com/lumi/backend/global/apiPayload/code/BaseSuccessCode.java
@@ -1,0 +1,10 @@
+package com.lumi.backend.global.apiPayload.code;
+
+public interface BaseSuccessCode {
+
+    String getCode();
+
+    String getMessage();
+
+    int getHttpStatus();
+}

--- a/backend/src/main/java/com/lumi/backend/global/apiPayload/code/GeneralErrorCode.java
+++ b/backend/src/main/java/com/lumi/backend/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,19 @@
+package com.lumi.backend.global.apiPayload.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GeneralErrorCode implements BaseErrorCode {
+
+    BAD_REQUEST("COMMON400_1", "잘못된 요청입니다.", 400),
+    UNAUTHORIZED("COMMON401_1", "인증이 필요합니다.", 401),
+    FORBIDDEN("COMMON403_1", "접근 권한이 없습니다.", 403),
+    NOT_FOUND("COMMON404_1", "요청한 리소스를 찾을 수 없습니다.", 404),
+    INTERNAL_SERVER_ERROR("COMMON500_1", "서버 내부 오류가 발생했습니다.", 500);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+}

--- a/backend/src/main/java/com/lumi/backend/global/apiPayload/code/GeneralSuccessCode.java
+++ b/backend/src/main/java/com/lumi/backend/global/apiPayload/code/GeneralSuccessCode.java
@@ -1,0 +1,18 @@
+package com.lumi.backend.global.apiPayload.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GeneralSuccessCode implements BaseSuccessCode {
+
+    OK("COMMON200_1", "요청이 성공적으로 처리되었습니다.", 200),
+    CREATED("COMMON201_1", "리소스가 성공적으로 생성되었습니다.", 201),
+    ACCEPTED("COMMON202_1", "요청이 수락되었습니다.", 202),
+    NO_CONTENT("COMMON204_1", "처리가 완료되었습니다.", 204);
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+}

--- a/backend/src/main/java/com/lumi/backend/global/apiPayload/exception/GeneralException.java
+++ b/backend/src/main/java/com/lumi/backend/global/apiPayload/exception/GeneralException.java
@@ -1,0 +1,15 @@
+package com.lumi.backend.global.apiPayload.exception;
+
+import com.lumi.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public GeneralException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/src/main/java/com/lumi/backend/global/apiPayload/exception/handler/GeneralExceptionHandler.java
+++ b/backend/src/main/java/com/lumi/backend/global/apiPayload/exception/handler/GeneralExceptionHandler.java
@@ -1,0 +1,61 @@
+package com.lumi.backend.global.apiPayload.exception.handler;
+
+import com.lumi.backend.global.apiPayload.ApiResponse;
+import com.lumi.backend.global.apiPayload.code.GeneralErrorCode;
+import com.lumi.backend.global.apiPayload.exception.GeneralException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GeneralExceptionHandler {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException e) {
+        log.warn("GeneralException: {}", e.getMessage());
+        ApiResponse<Void> response = ApiResponse.onFailure(e.getErrorCode(), null);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, List<String>>>> handleValidationException(MethodArgumentNotValidException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+
+        String message = fieldErrors.isEmpty()
+                ? GeneralErrorCode.BAD_REQUEST.getMessage()
+                : fieldErrors.get(0).getDefaultMessage();
+
+        Map<String, List<String>> fieldErrorMap = fieldErrors.stream()
+                .collect(Collectors.groupingBy(
+                        FieldError::getField,
+                        Collectors.mapping(FieldError::getDefaultMessage, Collectors.toList())
+                ));
+
+        log.warn("ValidationException: {}", message);
+
+        ApiResponse<Map<String, List<String>>> response = ApiResponse.<Map<String, List<String>>>builder()
+                .isSuccess(false)
+                .code(GeneralErrorCode.BAD_REQUEST.getCode())
+                .message(message)
+                .result(fieldErrorMap.isEmpty() ? null : fieldErrorMap)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled exception: {}", e.getMessage(), e);
+        ApiResponse<Void> response = ApiResponse.onFailure(GeneralErrorCode.INTERNAL_SERVER_ERROR, null);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/backend/src/main/java/com/lumi/backend/global/config/WebClientConfig.java
+++ b/backend/src/main/java/com/lumi/backend/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.lumi.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/backend/src/main/java/com/lumi/backend/global/entity/BaseEntity.java
+++ b/backend/src/main/java/com/lumi/backend/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.lumi.backend.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## Summary
- apiPayload 공통 코드 인터페이스 및 enum 추가 (BaseErrorCode, BaseSuccessCode, GeneralErrorCode, GeneralSuccessCode)
- ApiResponse 공통 응답 래퍼 추가 (@JsonProperty, @JsonInclude 적용)
- GeneralException 및 GeneralExceptionHandler 추가 (필드별 검증 에러 반환)
- WebClientConfig, BaseEntity 추가 (@EnableJpaAuditing 포함)

## 관련 이슈
closes #2