### PR TITLE
fix: AiClientImpl block() null 응답 NPE 방어 처리

### DIFF
--- a/backend/src/main/java/com/lumi/backend/analyze/client/AiClientImpl.java
+++ b/backend/src/main/java/com/lumi/backend/analyze/client/AiClientImpl.java
@@ -36,6 +36,10 @@ public class AiClientImpl implements AiClient {
                 .onErrorMap(e -> new AnalyzeException(AnalyzeErrorCode.AI_SERVER_ERROR))
                 .block();
 
+        if (response == null) {
+            throw new AnalyzeException(AnalyzeErrorCode.AI_SERVER_ERROR);
+        }
+
         return AnalyzeResponse.builder()
                 .summary(response.getSummary())
                 .errors(response.getErrors())


### PR DESCRIPTION
## 변경 사항
- `.block()` 반환값이 null인 경우 `AnalyzeException(AI_SERVER_ERROR)` 처리 추가

## 관련 이슈
closes #7