### PR TITLE
refactor: AiClientImpl AI 서버 URL 구성 방식을 UriComponentsBuilder로 변경

### DIFF
--- a/backend/src/main/java/com/lumi/backend/analyze/client/AiClientImpl.java
+++ b/backend/src/main/java/com/lumi/backend/analyze/client/AiClientImpl.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
@@ -28,7 +29,7 @@ public class AiClientImpl implements AiClient {
                 .build();
 
         AiAnalyzeResponse response = webClient.post()
-                .uri(aiServerUrl + "/analyze")
+                .uri(UriComponentsBuilder.fromHttpUrl(aiServerUrl).pathSegment("analyze").toUriString())
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(AiAnalyzeResponse.class)


### PR DESCRIPTION
## 변경 사항
- 문자열 접합(`aiServerUrl + "/analyze"`) 방식을 `UriComponentsBuilder.pathSegment()`로 교체
- URL 끝 슬래시 유무와 무관하게 안전하게 URL 구성

## 관련 이슈
closes #8