### PR TITLE
fix: AiClientImpl 에러 로그에 예외 메시지 포함

### DIFF
--- a/backend/src/main/java/com/lumi/backend/analyze/client/AiClientImpl.java
+++ b/backend/src/main/java/com/lumi/backend/analyze/client/AiClientImpl.java
@@ -32,7 +32,7 @@ public class AiClientImpl implements AiClient {
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(AiAnalyzeResponse.class)
-                .doOnError(e -> log.error("AI 서버 호출 실패: {}", e.getClass().getSimpleName()))
+                .doOnError(e -> log.error("AI 서버 호출 실패: {} - {}", e.getClass().getSimpleName(), e.getMessage()))
                 .onErrorMap(e -> new AnalyzeException(AnalyzeErrorCode.AI_SERVER_ERROR))
                 .block();
 


### PR DESCRIPTION
## 변경 사항
- `doOnError` 로그에 `e.getMessage()` 추가
- 예외 클래스명만 찍히던 로그에서 실제 원인 메시지 확인 가능

## 관련 이슈
closes #10