### PR TITLE
test: fixture 클래스 분리 및 Controller 예외 케이스 테스트 추가

### DIFF
--- a/backend/src/test/java/com/lumi/backend/analyze/controller/AnalyzeControllerTest.java
+++ b/backend/src/test/java/com/lumi/backend/analyze/controller/AnalyzeControllerTest.java
@@ -3,15 +3,16 @@ package com.lumi.backend.analyze.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lumi.backend.analyze.dto.AnalyzeRequest;
 import com.lumi.backend.analyze.dto.AnalyzeResponse;
+import com.lumi.backend.analyze.exceptions.AnalyzeException;
+import com.lumi.backend.analyze.exceptions.code.AnalyzeErrorCode;
 import com.lumi.backend.analyze.service.AnalyzeService;
+import com.lumi.backend.fixture.AnalyzeFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -34,15 +35,8 @@ class AnalyzeControllerTest {
     @Test
     void analyzeLog_정상요청_200반환() throws Exception {
         // given
-        AnalyzeRequest request = AnalyzeRequest.builder()
-                .log("java.lang.NullPointerException at com.lumi.Service.java:42")
-                .build();
-
-        AnalyzeResponse response = AnalyzeResponse.builder()
-                .summary("NullPointerException 발생")
-                .errors(List.of("com.lumi.Service.java:42"))
-                .suggestion("null 체크 추가 필요")
-                .build();
+        AnalyzeRequest request = AnalyzeFixture.createRequest();
+        AnalyzeResponse response = AnalyzeFixture.createResponse();
 
         given(analyzeService.analyzeLog(any())).willReturn(response);
 
@@ -77,14 +71,33 @@ class AnalyzeControllerTest {
     @Test
     void analyzeLog_null로그_400반환() throws Exception {
         // given
-        String requestBody = "{\"log\": null}";
+        AnalyzeRequest request = AnalyzeRequest.builder()
+                .log(null)
+                .build();
 
         // when & then
         mockMvc.perform(post("/api/analyze")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.isSuccess").value(false))
                 .andExpect(jsonPath("$.code").value("COMMON400_1"));
+    }
+
+    @Test
+    void analyzeLog_AI서버오류_500반환() throws Exception {
+        // given
+        AnalyzeRequest request = AnalyzeFixture.createRequest();
+
+        given(analyzeService.analyzeLog(any()))
+                .willThrow(new AnalyzeException(AnalyzeErrorCode.AI_SERVER_ERROR));
+
+        // when & then
+        mockMvc.perform(post("/api/analyze")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("ANALYZE500_1"));
     }
 }

--- a/backend/src/test/java/com/lumi/backend/analyze/service/AnalyzeServiceImplTest.java
+++ b/backend/src/test/java/com/lumi/backend/analyze/service/AnalyzeServiceImplTest.java
@@ -5,13 +5,12 @@ import com.lumi.backend.analyze.dto.AnalyzeRequest;
 import com.lumi.backend.analyze.dto.AnalyzeResponse;
 import com.lumi.backend.analyze.exceptions.AnalyzeException;
 import com.lumi.backend.analyze.exceptions.code.AnalyzeErrorCode;
+import com.lumi.backend.fixture.AnalyzeFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,15 +28,8 @@ class AnalyzeServiceImplTest {
     @Test
     void analyzeLog_정상요청_응답반환() {
         // given
-        AnalyzeRequest request = AnalyzeRequest.builder()
-                .log("java.lang.NullPointerException at com.lumi.Service.java:42")
-                .build();
-
-        AnalyzeResponse expected = AnalyzeResponse.builder()
-                .summary("NullPointerException 발생")
-                .errors(List.of("com.lumi.Service.java:42"))
-                .suggestion("null 체크 추가 필요")
-                .build();
+        AnalyzeRequest request = AnalyzeFixture.createRequest();
+        AnalyzeResponse expected = AnalyzeFixture.createResponse();
 
         given(aiClient.analyzeLog(request.getLog())).willReturn(expected);
 
@@ -53,9 +45,7 @@ class AnalyzeServiceImplTest {
     @Test
     void analyzeLog_AiClient실패_예외발생() {
         // given
-        AnalyzeRequest request = AnalyzeRequest.builder()
-                .log("java.lang.NullPointerException at com.lumi.Service.java:42")
-                .build();
+        AnalyzeRequest request = AnalyzeFixture.createRequest();
 
         given(aiClient.analyzeLog(request.getLog()))
                 .willThrow(new AnalyzeException(AnalyzeErrorCode.AI_SERVER_ERROR));

--- a/backend/src/test/java/com/lumi/backend/fixture/AnalyzeFixture.java
+++ b/backend/src/test/java/com/lumi/backend/fixture/AnalyzeFixture.java
@@ -1,0 +1,25 @@
+package com.lumi.backend.fixture;
+
+import com.lumi.backend.analyze.dto.AnalyzeRequest;
+import com.lumi.backend.analyze.dto.AnalyzeResponse;
+
+import java.util.List;
+
+public class AnalyzeFixture {
+
+    public static final String SAMPLE_LOG = "java.lang.NullPointerException at com.lumi.Service.java:42";
+
+    public static AnalyzeRequest createRequest() {
+        return AnalyzeRequest.builder()
+                .log(SAMPLE_LOG)
+                .build();
+    }
+
+    public static AnalyzeResponse createResponse() {
+        return AnalyzeResponse.builder()
+                .summary("NullPointerException 발생")
+                .errors(List.of("com.lumi.Service.java:42"))
+                .suggestion("null 체크 추가 필요")
+                .build();
+    }
+}


### PR DESCRIPTION
## 변경 사항
- `test/fixture/AnalyzeFixture.java` 생성 — 공통 테스트 객체 재사용
- `AnalyzeControllerTest`, `AnalyzeServiceImplTest` fixture 적용
- `AnalyzeControllerTest`에 `AI_SERVER_ERROR` 500 응답 케이스 추가
- `analyzeLog_null로그_400반환` 테스트를 ObjectMapper로 통일

## 관련 이슈
closes #11