### PR TITLE
[feat] 로그 분석 React UI 구현 (#21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__/
 
 # IntelliJ module files
 *.iml
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,98 @@
+# Frontend 작업 규칙
+
+## 기술 스택
+- React 18, Vite, JavaScript (TypeScript 아님)
+- 스타일: 일반 CSS 파일 / CSS Module (Tailwind 없음)
+- 상태관리: useState / useContext (외부 라이브러리 없음)
+
+---
+
+## 개발 명령어
+```bash
+npm run dev      # 개발 서버 (localhost:5173)
+npm run build    # 프로덕션 빌드
+npm run preview  # 빌드 결과 미리보기
+npm run lint     # ESLint 실행
+```
+
+---
+
+## 폴더 구조
+```
+src/
+├── api/          # API 호출 함수 (컴포넌트 안에서 직접 fetch 금지)
+├── components/   # 재사용 가능한 UI 컴포넌트
+├── pages/        # 페이지 단위 컴포넌트 (상태 관리 담당)
+├── hooks/        # 커스텀 훅
+└── assets/       # 이미지, 폰트 등 정적 파일
+```
+
+---
+
+## 컴포넌트 컨벤션
+- 함수형 컴포넌트만 사용 (클래스 컴포넌트 금지)
+- 파일명 / 컴포넌트명: PascalCase (`LogInput.jsx`)
+- default export 사용
+- 상태는 가능하면 Page 컴포넌트에서 관리하고 props로 내려줌
+- 비동기 처리는 `async/await` 사용 (`.then()` 체이닝 피하기)
+
+---
+
+## 스타일 컨벤션
+- 컴포넌트 공통 스타일: `components/components.css`
+- 전역 레이아웃/리셋: `App.css`
+- 기본 폰트/body 초기화: `index.css`
+- 클래스명: kebab-case (`.result-panel`, `.analyze-btn`)
+
+---
+
+## CSS 레이아웃 주의사항
+
+### Vite 기본 템플릿 초기화 시
+Vite 기본 `index.css`에는 아래 스타일이 포함되어 있어 전체 화면 레이아웃을 망친다.
+
+```css
+body {
+  display: flex;
+  place-items: center; /* ← 가로 너비를 좁게 만드는 원인 */
+}
+```
+
+**전체 화면 레이아웃 작업 시 `index.css`와 `#root`를 반드시 함께 확인하고 초기화한다.**
+
+권장 초기화:
+```css
+/* index.css */
+body { margin: 0; }
+
+#root {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+```
+
+---
+
+## 하지 말아야 할 것
+- 컴포넌트 안에서 직접 `fetch` / API 호출 — `src/api/`에 분리
+- `any` 타입 (JS라도 JSDoc으로 타입 힌트 권장)
+- `querySelector` 등 직접 DOM 조작
+- props drilling 3단계 이상 — 필요하면 Context 사용
+- 커밋 전 `console.log` 잔류
+
+---
+
+## API 연동 패턴
+실제 API 연결 전에는 `src/api/` 안에 mock 함수를 만들어두고,
+나중에 해당 함수 내부만 교체한다. 컴포넌트 코드는 건드리지 않는다.
+
+```js
+// src/api/analyzeApi.js
+export async function analyzeLog(log) {
+  // TODO: 실제 API로 교체
+  await new Promise(res => setTimeout(res, 1000));
+  return { summary: "...", errors: [], cause: "...", solution: "..." };
+}
+```

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,113 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #f3f4f6;
+  color: #111827;
+  min-height: 100vh;
+  display: block;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+/* ── Navbar ── */
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: #fff;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 0 40px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.navbar-logo {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #6366f1;
+  letter-spacing: -0.5px;
+}
+
+.navbar-sub {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+/* ── Page body ── */
+.page {
+  flex: 1;
+  min-height: 0;
+  padding: 28px 40px;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 4px;
+}
+
+.page-desc {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin-bottom: 32px;
+}
+
+/* ── Two-column layout ── */
+.workspace {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  flex: 1;
+  min-height: 0;
+}
+
+.panel {
+  background-color: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.panel-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #9ca3af;
+  margin-bottom: 12px;
+}
+
+.btn-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .navbar {
+    padding: 0 20px;
   }
-  to {
-    transform: rotate(360deg);
+
+  .page {
+    height: auto;
+    padding: 20px;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .workspace {
+    grid-template-columns: 1fr;
+    flex: unset;
   }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,35 +1,6 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import AnalyzePage from "./pages/AnalyzePage";
+import "./App.css";
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+export default function App() {
+  return <AnalyzePage />;
 }
-
-export default App

--- a/frontend/src/api/analyzeApi.js
+++ b/frontend/src/api/analyzeApi.js
@@ -1,0 +1,9 @@
+export async function analyzeLog(log) {
+  await new Promise(res => setTimeout(res, 1000));
+  return {
+    summary: "Mock summary",
+    errors: ["NullPointerException", "PaymentService error"],
+    cause: "Mock cause",
+    solution: "Mock solution",
+  };
+}

--- a/frontend/src/components/AnalyzeButton.jsx
+++ b/frontend/src/components/AnalyzeButton.jsx
@@ -1,0 +1,7 @@
+export default function AnalyzeButton({ isLoading, onClick }) {
+  return (
+    <button className="analyze-btn" onClick={onClick} disabled={isLoading}>
+      {isLoading ? "Analyzing..." : "Analyze"}
+    </button>
+  );
+}

--- a/frontend/src/components/LogInput.jsx
+++ b/frontend/src/components/LogInput.jsx
@@ -1,0 +1,11 @@
+export default function LogInput({ log, setLog }) {
+  return (
+    <textarea
+      className="log-input"
+      value={log}
+      onChange={(e) => setLog(e.target.value)}
+      placeholder="서버 로그를 붙여넣으세요..."
+      spellCheck={false}
+    />
+  );
+}

--- a/frontend/src/components/ResultPanel.jsx
+++ b/frontend/src/components/ResultPanel.jsx
@@ -1,0 +1,38 @@
+export default function ResultPanel({ result }) {
+  if (!result) {
+    return (
+      <div className="result-empty">
+        <span className="result-empty-icon">🔍</span>
+        <span>분석 결과가 여기에 표시됩니다.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="result-panel">
+      <div className="result-section">
+        <h3>Summary</h3>
+        <p>{result.summary}</p>
+      </div>
+
+      <div className="result-section errors">
+        <h3>Errors</h3>
+        <ul>
+          {result.errors.map((err, i) => (
+            <li key={i}>{err}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="result-section cause">
+        <h3>Cause</h3>
+        <p>{result.cause}</p>
+      </div>
+
+      <div className="result-section solution">
+        <h3>Solution</h3>
+        <p>{result.solution}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/components.css
+++ b/frontend/src/components/components.css
@@ -1,0 +1,115 @@
+.log-input {
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  padding: 14px;
+  font-family: monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  resize: none;
+  box-sizing: border-box;
+  background-color: #fafafa;
+  color: #111827;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.log-input:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.analyze-btn {
+  padding: 10px 32px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background-color: #6366f1;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s, opacity 0.2s;
+}
+
+.analyze-btn:hover:not(:disabled) {
+  background-color: #4f46e5;
+}
+
+.analyze-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Result Panel ── */
+.result-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: #d1d5db;
+  font-size: 0.9rem;
+  gap: 8px;
+}
+
+.result-empty-icon {
+  font-size: 2.5rem;
+}
+
+.result-panel {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.result-section {
+  border-left: 3px solid #6366f1;
+  background-color: #fafafa;
+  border-radius: 0 6px 6px 0;
+  padding: 14px 16px;
+}
+
+.result-section.errors {
+  border-left-color: #ef4444;
+}
+
+.result-section.cause {
+  border-left-color: #f59e0b;
+}
+
+.result-section.solution {
+  border-left-color: #10b981;
+}
+
+.result-section h3 {
+  margin: 0 0 8px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+}
+
+.result-section p {
+  margin: 0;
+  color: #374151;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.result-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: #374151;
+}
+
+.result-section ul li {
+  margin-bottom: 6px;
+  font-family: monospace;
+  font-size: 0.82rem;
+  color: #dc2626;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,17 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+*, *::before, *::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#root {
+  width: 100%;
+  height: 100vh;
   display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  flex-direction: column;
 }

--- a/frontend/src/pages/AnalyzePage.jsx
+++ b/frontend/src/pages/AnalyzePage.jsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import LogInput from "../components/LogInput";
+import AnalyzeButton from "../components/AnalyzeButton";
+import ResultPanel from "../components/ResultPanel";
+import { analyzeLog } from "../api/analyzeApi";
+import "../components/components.css";
+
+export default function AnalyzePage() {
+  const [log, setLog] = useState("");
+  const [result, setResult] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleAnalyze() {
+    if (!log.trim()) return;
+    setIsLoading(true);
+    try {
+      const data = await analyzeLog(log);
+      setResult(data);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <nav className="navbar">
+        <span className="navbar-logo">Lumi</span>
+        <span className="navbar-sub">AI Log Analyzer</span>
+      </nav>
+
+      <div className="page">
+        <p className="page-title">로그 분석</p>
+        <p className="page-desc">서버 로그를 붙여넣으면 AI가 에러 원인과 해결책을 분석합니다.</p>
+
+        <div className="workspace">
+          <div className="panel">
+            <p className="panel-label">Log Input</p>
+            <LogInput log={log} setLog={setLog} />
+            <div className="btn-row">
+              <AnalyzeButton isLoading={isLoading} onClick={handleAnalyze} />
+            </div>
+          </div>
+
+          <div className="panel">
+            <p className="panel-label">Analysis Result</p>
+            <ResultPanel result={result} />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## 변경 사항
- mock API 함수 구현 (`analyzeApi.js`)
- LogInput / AnalyzeButton / ResultPanel 컴포넌트 구현
- AnalyzePage 상태 관리 및 컴포넌트 연결
- 전체 화면 레이아웃 및 2단 컬럼 UI 적용
- frontend CLAUDE.md 작성
- `.claude/settings.local.json` gitignore 추가

## 관련 이슈
closes #21